### PR TITLE
For older version of OpenCL

### DIFF
--- a/hello.c
+++ b/hello.c
@@ -48,7 +48,11 @@ int main()
   context = clCreateContext(NULL, 1, &device_id, NULL, NULL, &ret);
 
   /* Create Command Queue */
+  #ifdef CL_VERSION_2_0
   command_queue = clCreateCommandQueueWithProperties(context, device_id, 0, &ret);
+  #else
+  command_queue = clCreateCommandQueue(context, device_id, 0, &ret);
+  #endif
 
   /* Create Memory Buffer */
   memobj = clCreateBuffer(context, CL_MEM_READ_WRITE,MEM_SIZE * sizeof(char), NULL, &ret);

--- a/matrix_dot_matrix.c
+++ b/matrix_dot_matrix.c
@@ -135,7 +135,11 @@ int main(int argc, char *argv[]) {
   context = clCreateContext(NULL, 1, &device_id, NULL, NULL, &ret);
 
   /* Create Command Queue */
+  #ifdef CL_VERSION_2_0
   command_queue = clCreateCommandQueueWithProperties(context, device_id, 0, &ret);
+  #else
+  command_queue = clCreateCommandQueue(context, device_id, 0, &ret);
+  #endif
 
   /* Create Kernel Program from the source */
   program = clCreateProgramWithSource(context, 1, (const char **)&source_str, (const size_t *)&source_size, &ret);


### PR DESCRIPTION
Your code can be compiled only in OpenCL 2.0, though it can't be compiled in Mac, which adopts OpenCL 1.2.

In OpenCL 1.2, `clCreateCommandQueueWithProperties` should be replaced `clCreateCommandQueue`.
